### PR TITLE
Use --device=input instead of --device=all

### DIFF
--- a/com.github.shonumi.gbe-plus.json
+++ b/com.github.shonumi.gbe-plus.json
@@ -12,7 +12,8 @@
         /* GPU acceleration */
         "--device=dri",
         /* Joystick access */
-        "--device=all",
+        "--require-version=1.16.0",
+        "--device=input",
         /* Play sounds */
         "--socket=pulseaudio",
         /* Network play */


### PR DESCRIPTION
Seeing as we only use `--device=all` to access joysticks/controllers, we should use `--device=input` instead of `--device=all`.

This requires flatpak-1.15.6, which was released in 2024.

Closes: #11